### PR TITLE
Created a .gitattributes file. Now github should ignore the trace fil…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+resources/* linguist-vendored
+src/test/resources/* linguist-vendored


### PR DESCRIPTION
After this pull request, Github should correctly display the percentage of the programming languages used. 